### PR TITLE
#23 Express Route: Get followed artists

### DIFF
--- a/server/models/FollowedArtists.js
+++ b/server/models/FollowedArtists.js
@@ -1,0 +1,22 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+const followedArtistsSchema = new Schema({
+  spotify_uid: {
+    type: String,
+    unique: true
+  },
+  artists: [
+    {
+      name: {
+        type: String
+      },
+      artist_id: {
+        type: String,
+        unique: true
+      }
+    }
+  ]
+});
+
+mongoose.model("followed_Artists", followedArtistsSchema);

--- a/server/routes/spotify.js
+++ b/server/routes/spotify.js
@@ -25,13 +25,14 @@ router.get("/", (req, res) => {
 
 // TODO: Issue #23
 router.post("/followed_artists", validateAccessToken, (req, res) => {
-  spotifyApi.setAccessToken("TODO: put req.accessToken here");
+  const { access_token, refresh_token } = req.body;
+  spotifyApi.setAccessToken(access_token);
 
-  spotifyApi.getFollowedArtists({ limit: 50 }).then(
+  spotifyApi.getFollowedArtists({ limit: 4 }).then(
     function(data) {
       res.send({
         path: "/followed_artists",
-        data: data.body
+        data: data.body.artists.items[0].name
       });
     },
     function(err) {

--- a/server/routes/spotify.js
+++ b/server/routes/spotify.js
@@ -4,6 +4,9 @@ const router = express.Router();
 const SpotifyWebApi = require("spotify-web-api-node");
 // Middleware
 const validateAccessToken = require("../middleware/spotify/validate_access_token");
+// Mongoose
+const mongoose = require("mongoose");
+const FollowedArtists = mongoose.model("followed_Artists");
 
 // .env imports
 const client_id = process.env.SPOTIFY_CLIENT_ID; // Your client id
@@ -23,22 +26,47 @@ router.get("/", (req, res) => {
   });
 });
 
-// TODO: Issue #23
-router.post("/followed_artists", validateAccessToken, (req, res) => {
-  const { access_token, refresh_token } = req.body;
+router.post("/refresh_followed_artists", validateAccessToken, (req, res) => {
+  const { access_token, refresh_token, spotify_uid } = req.body;
   spotifyApi.setAccessToken(access_token);
 
-  spotifyApi.getFollowedArtists({ limit: 4 }).then(
-    function(data) {
+  spotifyApi.getFollowedArtists({ limit: 50 }).then(
+    async data => {
+      const items = data.body.artists.items;
+      const artistArray = [];
+
+      items.forEach(artist => {
+        const current_artist = {
+          name: artist.name,
+          artist_id: artist.id
+        };
+        artistArray.push(current_artist);
+      });
+
+      const followerList = await FollowedArtists.findOneAndUpdate(
+        { spotify_uid },
+        { artists: artistArray }
+      );
+
       res.send({
-        path: "/followed_artists",
-        data: data.body.artists.items[0].name
+        path: "/refresh_followed_artists",
+        data: followerList.spotify_uid
       });
     },
     function(err) {
       console.log("Something went wrong!", err);
     }
   );
+});
+
+// TODO: Issue #23
+router.post("/followed_artists", async (req, res) => {
+  const { spotify_uid } = req.body;
+  const followerList = await FollowedArtists.findOne({ spotify_uid });
+  res.send({
+    path: "/followed_artists",
+    artists: followerList.artists
+  });
 });
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -26,6 +26,7 @@ app
 const mongoose = require("mongoose");
 mongoose.connect(process.env.MONGO_URI);
 require("./models/Users");
+require("./models/FollowedArtists");
 
 // Logging
 const pino = require("express-pino-logger")();

--- a/server/services/passport.js
+++ b/server/services/passport.js
@@ -10,6 +10,7 @@ const redirect_uri = process.env.SPOTIFY_REDIRECT_URI; // Your redirect uri
 // Mongoose
 const mongoose = require("mongoose");
 const User = mongoose.model("users");
+const FollowedArtists = mongoose.model("followed_Artists");
 
 passport.serializeUser((user, done) => {
   done(null, user.id);
@@ -40,10 +41,18 @@ passport.use(
             email: profile.emails[0].value,
             photos: profile.photos
           });
+          const followedArtists = new FollowedArtists({
+            spotify_uid: profile.id
+          });
+
           try {
-            newUser.save(err => {
+            followedArtists.save(err => {
               if (err) throw new Error(err);
-              return done(null, profile);
+
+              newUser.save(err => {
+                if (err) throw new Error(err);
+                return done(null, profile);
+              });
             });
           } catch (err) {
             console.log("Error saving new user.. : ", err);


### PR DESCRIPTION
* /followed_artists now retrieves access_token and refresh_token from req.body
* Creates followed_artists set in mongoDB. It's a relational set to the user's account with their spotify_uid. 
* Creates '/refresh_followed_artists' route to populate the user's followed_artists set
* New users now have a followed_artist set created automatically with their spotify_uid tied to it.
* '/followed_artists' retrieves the user's followed artists from the database and returns them.